### PR TITLE
Add support for pipsi update

### DIFF
--- a/pipsi.py
+++ b/pipsi.py
@@ -26,6 +26,19 @@ def install_package(module, package_name, python):
     )
 
 
+def update_package(module, package_name, python):
+    if not is_package_installed(module, package_name):
+        install_package(module, package_name, python)
+
+    else:
+        cmd = ['pipsi', 'update', '--python', python, package_name]
+        module.run_command(cmd, check_rc=True)
+        module.exit_json(
+            changed=True,
+            msg='installed package'
+        )
+
+
 def remove_package(module, package_name):
     if not is_package_installed(module, package_name):
         module.exit_json(
@@ -50,7 +63,7 @@ def main():
             },
             'state': {
                 'default': 'present',
-                'choices': ['present', 'absent'],
+                'choices': ['present', 'absent', 'latest'],
             },
             'python': {
                 'default': ''
@@ -61,6 +74,8 @@ def main():
 
     if params['state'] == 'present':
         install_package(module, params['name'], params['python'])
+    elif params['state'] == 'latest':
+        update_package(module, params['name'], params['python'])
     elif params['state'] == 'absent':
         remove_package(module, params['name'])
 

--- a/pipsi.py
+++ b/pipsi.py
@@ -31,12 +31,18 @@ def update_package(module, package_name, python):
         install_package(module, package_name, python)
 
     else:
-        cmd = ['pipsi', 'update', '--python', python, package_name]
-        module.run_command(cmd, check_rc=True)
-        module.exit_json(
-            changed=True,
-            msg='installed package'
-        )
+        cmd = ['pipsi', 'upgrade', package_name]
+        rc, out, _ = module.run_command(cmd)
+        if rc and 'up-to-date' in out:
+            module.exit_json(
+                changed=False,
+                msg='Package up to date'
+            )
+        elif not rc:
+            module.exit_json(
+                changed=True,
+                msg='upgraded package'
+            )
 
 
 def remove_package(module, package_name):


### PR DESCRIPTION
This includes support for update [#1], using `state: latest`. Where packages are not already present this defers to the install function.

